### PR TITLE
Use ellipsis if task title overflows

### DIFF
--- a/src/app/components/task/task/task.component.html
+++ b/src/app/components/task/task/task.component.html
@@ -21,6 +21,7 @@
       name="title-{{ task.id }}"
       id="title-{{ task.id }}"
       placeholder="Input title"
+      style="text-overflow: ellipsis"
     />
   </label>
   <button

--- a/src/app/components/task/task/task.stories.ts
+++ b/src/app/components/task/task/task.stories.ts
@@ -45,3 +45,11 @@ Archived.args = {
     state: 'TASK_ARCHIVED',
   },
 };
+
+export const LongTitle = Template.bind({});
+LongTitle.args = {
+  task: {
+    ...Default.args['task'],
+    title: `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`,
+  },
+};


### PR DESCRIPTION
Changes:

- Fix issue with task titles being cut off if they're too long by using an ellipsis
- Add Storybook story that covers this test case